### PR TITLE
Fix MACAROON_PATH in env

### DIFF
--- a/.env
+++ b/.env
@@ -17,4 +17,4 @@ DB_ROOT_PASS=mempool # Root password
 
 LND_NETWORK=mainnet
 TLS_CERT_PATH=./lnd_data/tls.cert
-MACAROON_PATH=-./lnd_data
+MACAROON_PATH=./lnd_data


### PR DESCRIPTION
## Summary
- correct the `MACAROON_PATH` value in `.env`
- ensure the file ends with a newline

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849476876f8832eb7e08d162f6cffc8