### PR TITLE
Add Docker Compose lint workflow

### DIFF
--- a/.github/workflows/compose-lint.yml
+++ b/.github/workflows/compose-lint.yml
@@ -1,0 +1,14 @@
+name: Compose Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate docker-compose configuration
+        run: docker-compose -f docker-compose.yml config


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint the Compose file

## Testing
- `docker-compose -f docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494778f0ac832eab75513cfe4e58a1