### PR TITLE
Update service versions

### DIFF
--- a/Dockerfiles/Bitcoin.Dockerfile
+++ b/Dockerfiles/Bitcoin.Dockerfile
@@ -5,8 +5,8 @@ FROM alpine AS build
 RUN apk --no-cache add autoconf automake libtool boost-dev libevent-dev libffi-dev openssl-dev bash coreutils git cmake && \
     apk --no-cache add --update alpine-sdk build-base curl
 
-# Define the Bitcoin version to build (default is version 26.2)
-ARG VERSION=28.1
+# Define the Bitcoin version to build (default is version 29.0)
+ARG VERSION=29.0
 ENV BITCOIN_VERSION=${BITCOIN_VERSION}
 
 # Clone the specific version of the Bitcoin source code from the official repository

--- a/Dockerfiles/BitcoinExporter.Dockerfile
+++ b/Dockerfiles/BitcoinExporter.Dockerfile
@@ -1,5 +1,5 @@
 # Use an Alpine image as the base
-FROM golang:1.22-alpine3.20 AS builder
+FROM golang:1.22.12-alpine3.21 AS builder
 
 
 # Install necessary packages for building and running the project
@@ -30,7 +30,7 @@ RUN go build -o bitcoind-exporter
 # Expose the port that the application will use
 EXPOSE 9999
 
-FROM alpine:3.20 AS final
+FROM alpine:3.21 AS final
 
 COPY --from=builder /app/bitcoind-exporter /usr/bin/bitcoind-exporter
 

--- a/Dockerfiles/LND.Dockerfile
+++ b/Dockerfiles/LND.Dockerfile
@@ -3,7 +3,7 @@
 # /make/builder.Dockerfile
 # /.github/workflows/main.yml
 # /.github/workflows/release.yml
-FROM golang:1.23.6-alpine as builder
+FROM golang:1.23.10-alpine as builder
 
 # Force Go to use the cgo based DNS resolver. This is required to ensure DNS
 # queries required to connect to linked containers succeed.
@@ -12,7 +12,7 @@ ENV GODEBUG netdns=cgo
 # Pass a tag, branch or a commit using build-arg.  This allows a docker
 # image to be built from a specified Git state.  The default image
 # will use the Git tip of master by default.
-ARG checkout="master"
+ARG checkout="v0.19.0-beta"
 ARG git_url="https://github.com/lightningnetwork/lnd"
 
 # Install dependencies and build the binaries.

--- a/Dockerfiles/LNDmon.Dockerfile
+++ b/Dockerfiles/LNDmon.Dockerfile
@@ -2,7 +2,7 @@
 # /Dockerfile
 # /tools/Dockerfile
 # /.github/workflows/main.yml
-FROM golang:1.21.6-alpine as builder
+FROM golang:1.22.12-alpine as builder
 
 # Install build dependencies such as git and glide.
 RUN apk add --no-cache git gcc musl-dev
@@ -15,7 +15,7 @@ RUN apk add --no-cache --update alpine-sdk \
 
 ENV GO111MODULE on
 #Clone the repository
-RUN git clone https://github.com/lightninglabs/lndmon.git /go/src/github.com/lightninglabs/lndmon/
+RUN git clone --branch v0.2.8 --depth 1 https://github.com/lightninglabs/lndmon.git /go/src/github.com/lightninglabs/lndmon/
 
 #Build lndmon
 RUN cd /go/src/github.com/lightninglabs/lndmon/cmd/lndmon && go build

--- a/Dockerfiles/LnBits.Dockerfile
+++ b/Dockerfiles/LnBits.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-bookworm AS builder
+FROM python:3.12-slim-bookworm AS builder
 
 RUN apt-get clean
 RUN apt-get update
@@ -7,7 +7,7 @@ RUN apt-get install -y curl pkg-config build-essential libnss-myhostname git
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:$PATH"
 
-RUN git clone https://github.com/lnbits/lnbits.git /app
+RUN git clone --branch v1.1.0 --depth 1 https://github.com/lnbits/lnbits.git /app
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ ENV POETRY_NO_INTERACTION=1 \
 
 RUN poetry install --only main
 
-FROM python:3.10-slim-bookworm
+FROM python:3.12-slim-bookworm
 
 # needed for backups postgresql-client version 14 (pg_dump)
 RUN apt-get update && apt-get -y upgrade && \
@@ -42,7 +42,7 @@ ENV POETRY_NO_INTERACTION=1 \
     VIRTUAL_ENV=/app/.venv \
     PATH="/app/.venv/bin:$PATH"
 
-RUN git clone https://github.com/lnbits/lnbits.git /app
+RUN git clone --branch v1.1.0 --depth 1 https://github.com/lnbits/lnbits.git /app
 
 WORKDIR /app
 

--- a/Dockerfiles/Thunderhub.Dockerfile
+++ b/Dockerfiles/Thunderhub.Dockerfile
@@ -1,7 +1,7 @@
 # ---------------
 # Install Dependencies
 # ---------------
-    FROM node:18.18.2-alpine AS deps
+    FROM node:22.16.0-alpine AS deps
 
     WORKDIR /app
     
@@ -14,7 +14,7 @@
       git
     
     # Clone repository
-    RUN git clone https://github.com/apotdevin/thunderhub.git .
+    RUN git clone --branch v0.13.31 --depth 1 https://github.com/apotdevin/thunderhub.git .
     #Preconfigure
     RUN npm ci
     
@@ -42,7 +42,7 @@
     # ---------------
     # Release App
     # ---------------
-    FROM node:18.18.2-alpine AS final
+    FROM node:22.16.0-alpine AS final
     
     WORKDIR /app
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       LIQUID_ENABLED: true
       MEMPOOL_WEBSITE_URL: https://mempool.hiemercloud.de
       LIQUID_WEBSITE_URL: https://liquid.hiemercloud.de
-    image: mempool/frontend:latest
+    image: mempool/frontend:v3.2.1
     user: root
     restart: on-failure
     stop_grace_period: 1m
@@ -60,7 +60,7 @@ services:
       LND_REST_API_URL: "https://${SUBNET_ADDR}.8:8080"
       LND_TIMEOUT: 1000
     
-    image: mempool/backend:latest
+    image: mempool/backend:v3.2.1
     user: root
     restart: on-failure
     stop_grace_period: 1m
@@ -87,7 +87,7 @@ services:
       MYSQL_USER: "${DB_USER}"
       MYSQL_PASSWORD: "${DB_PASS}"
       MYSQL_ROOT_PASSWORD: "${DB_ROOT_PASS}"
-    image: mariadb:10.5.21
+    image: mariadb:11.8
     user: root
     restart: on-failure
     stop_grace_period: 1m


### PR DESCRIPTION
## Summary
- bump Bitcoin to v29.0
- use Python 3.12 and lnbits v1.1.0
- update LND to v0.19.0-beta
- update lndmon to v0.2.8
- use Node 22 and thunderhub v0.13.31
- update Go versions for exporter and lndmon
- update compose images to mempool v3.2.1 and mariadb 11.8

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849469ec9a0832eb594980e4806cadb